### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/444main.yml
+++ b/.github/workflows/444main.yml
@@ -12,7 +12,7 @@ jobs:
       run:
         mvn clean package -DskipTests=true -Dmaven.javadoc.skip=true -B -V
     - name: Publish Docker
-      uses: elgohr/Publish-Docker-Github-Action@2.11
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         # The name of the image you would like to push
         name: ${{secrets.DOCKER_PROGRAM}}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore